### PR TITLE
#161267094: Return user object with comment and comment thread

### DIFF
--- a/server/controllers/CommentThreadsController.js
+++ b/server/controllers/CommentThreadsController.js
@@ -4,6 +4,7 @@ import db from '../database/models';
 const {
   Comment,
   CommentThread,
+  User,
 } = db;
 
 /**
@@ -146,7 +147,11 @@ class CommentThreadsControllers {
         id: {
           [Op.eq]: req.params.id
         }
-      }
+      },
+      include: [{
+        model: User,
+        attributes: ['username', 'email', 'image'],
+      }],
     }).then((comment) => {
       if (!comment) {
         return res.status(404).json({
@@ -163,7 +168,11 @@ class CommentThreadsControllers {
         order: ['id'],
         attributes: ['id', 'createdAt', 'updatedAt', 'body'],
         offset,
-        limit
+        limit,
+        include: [{
+          model: User,
+          attributes: ['username', 'email', 'image'],
+        }],
       }).then((replies) => {
         const { count } = replies;
         const pageCount = Math.ceil(count / limit);
@@ -178,7 +187,6 @@ class CommentThreadsControllers {
           },
           replies: {
             ...replies.rows,
-            user: req.decoded
           },
           repliesCount: replies.count,
         });

--- a/server/controllers/CommentsController.js
+++ b/server/controllers/CommentsController.js
@@ -5,6 +5,7 @@ import db from '../database/models';
 const {
   Article,
   Comment,
+  User,
 } = db;
 
 /**
@@ -187,7 +188,11 @@ class CommentsControllers {
         order: ['id'],
         attributes: ['id', 'createdAt', 'updatedAt', 'body'],
         offset,
-        limit
+        limit,
+        include: [{
+          model: User,
+          attributes: ['username', 'email', 'image'],
+        }],
       }).then((comments) => {
         const { count } = comments;
         const pageCount = Math.ceil(count / limit);
@@ -202,7 +207,6 @@ class CommentsControllers {
           },
           comments: {
             ...comments.rows,
-            user: req.decoded
           },
           commentsCount: count,
         });

--- a/server/test/comment.spec.js
+++ b/server/test/comment.spec.js
@@ -207,6 +207,9 @@ describe('Test API endpoint to comment on articles', () => {
         expect(res.body.comments['0'].body).to.equal('This article is hot');
         expect(res.body.comments['1'].body).to.equal('This article is correct');
         expect(res.body.comments['2'].body).to.equal('updated article');
+        expect(res.body.comments['0'].User.username).to.equal('joeeasy');
+        expect(res.body.comments['1'].User.username).to.equal('faksam');
+        expect(res.body.comments['2'].User.username).to.equal('joeeasy');
         done();
       });
   });

--- a/server/test/commentThread.spec.js
+++ b/server/test/commentThread.spec.js
@@ -171,6 +171,8 @@ describe('Test API endpoint to replies on comments', () => {
         expect(res).to.have.status(200);
         expect(res.body.replies['0'].body).to.equal('updated reply');
         expect(res.body.replies['1'].body).to.equal('This article is best here too');
+        expect(res.body.replies['0'].User.username).to.equal('joeeasy');
+        expect(res.body.replies['1'].User.username).to.equal('faksam');
         done();
       });
   });


### PR DESCRIPTION
#### What does this PR do?
- Fixes returned comments to include a user object for each comment
- Fixes returned comment thread to include a user object for each comment thread

#### Description of Task to be completed?
- Test to check if user object is returned with each comment
- Test to check if user object is returned with each comment thread
- Return user object with each comment
- Return user object with comment thread

#### How should this be manually tested?
- clone this repo
- run `npm install`
- run `npm start dev`
- use postman to get all comments 
GET `/api/articles/:slug/comments`
- use postman to get all comment thread
GET `/api/comments/:id/replies`

#### Any background context you want to provide?
- N/A
#### What are the relevant pivotal tracker stories?(if applicable)
[#161267094](https://www.pivotaltracker.com/story/show/161267094)